### PR TITLE
Add Job Metadata

### DIFF
--- a/tests/jobs/resources.py
+++ b/tests/jobs/resources.py
@@ -15,7 +15,7 @@ import typing
 
 import pandas as pd
 
-from rialto.jobs.job_base import JobBase
+from rialto.jobs.job_base import JobBase, JobMetadata
 from rialto.jobs.resolver import Resolver
 
 
@@ -34,8 +34,11 @@ class CustomJobNoReturnVal(JobBase):
     def get_job_name(self) -> str:
         return "job_name"
 
-    def get_job_version(self) -> str:
-        return "job_version"
+    def get_job_metadata(self) -> str:
+        return JobMetadata(job_name="job_name", dist_name="job_function", dist_version="1.0.0")
+
+    def get_disable_version(self) -> bool:
+        return False
 
     def get_custom_callable(self) -> typing.Callable:
         return custom_callable
@@ -52,8 +55,8 @@ class CustomJobReturnsDataFrame(CustomJobNoReturnVal):
 
 
 class CustomJobNoVersion(CustomJobNoReturnVal):
-    def get_job_version(self) -> str:
-        return None
+    def get_disable_version(self) -> bool:
+        return True
 
 
 def CustomJobAssertResolverSetup(CustomJobNoReturnVal):

--- a/tests/jobs/test_job/test_job.py
+++ b/tests/jobs/test_job/test_job.py
@@ -45,10 +45,12 @@ def disable_version_job_function():
 
 
 @job
-def job_asking_for_all_deps(spark, run_date, config, table_reader, metadata_manager, feature_loader):
+def job_asking_for_all_deps(spark, run_date, config, job_metadata, table_reader, metadata_manager, feature_loader):
     assert spark is not None
     assert run_date == 456
     assert config == 123
     assert table_reader == 789
     assert metadata_manager == 654
     assert feature_loader == 321
+    assert job_metadata is not None
+    assert job_metadata.dist_version == "N/A"

--- a/tests/jobs/test_job_base.py
+++ b/tests/jobs/test_job_base.py
@@ -50,7 +50,7 @@ def test_no_return_vaue_adds_version_timestamp_dataframe(spark):
 
     assert type(result) is pyspark.sql.DataFrame
     assert result.columns == ["JOB_NAME", "CREATION_TIME", "VERSION"]
-    assert result.first()["VERSION"] == "job_version"
+    assert result.first()["VERSION"] == "1.0.0"
     assert result.count() == 1
 
 
@@ -62,7 +62,7 @@ def test_return_dataframe_forwarded_with_version(spark):
 
     assert type(result) is pyspark.sql.DataFrame
     assert result.columns == ["FIRST", "SECOND", "VERSION"]
-    assert result.first()["VERSION"] == "job_version"
+    assert result.first()["VERSION"] == "1.0.0"
     assert result.count() == 2
 
 


### PR DESCRIPTION
@job decorator can now request job_metadata, which will return

```python3
class JobMetadata(BaseModel):
    job_name: str
    dist_name: str
    dist_version: str
```